### PR TITLE
Update brew Files for v2.0.10 Release

### DIFF
--- a/eosio.rb
+++ b/eosio.rb
@@ -2,8 +2,8 @@ class Eosio < Formula
 
    homepage "https://github.com/eosio/eos"
    revision 0
-   url "https://github.com/eosio/eos/archive/v2.0.9.tar.gz"
-   version "2.0.9"
+   url "https://github.com/eosio/eos/archive/v2.0.10.tar.gz"
+   version "2.0.10"
 
    option :universal
 
@@ -15,8 +15,8 @@ class Eosio < Formula
    depends_on :arch =>  :intel
 
    bottle do
-      root_url "https://github.com/eosio/eos/releases/download/v2.0.9"
-      sha256 "d497a0efcca1225f25501434aeffb0def78c35f4a038aedfeba453955be9025e" => :mojave
+      root_url "https://github.com/eosio/eos/releases/download/v2.0.10"
+      sha256 "fa395380186f3cd545da7444f3b38ccf5bd0ace0f4f85bd7023f15eb5066bfb8" => :mojave
    end
    def install
       raise "Error, only supporting binary packages at this time"


### PR DESCRIPTION
From [AUTO-601](https://blockone.atlassian.net/browse/AUTO-601) and [#help-automation](https://blockone.slack.com/archives/CMTAZ9L4D/p1614305209021300?thread_ts=1614304736.021000&cid=CMTAZ9L4D), the [`eosioBrewAutoPR`](https://github.com/EOSIO/auto-events-subscribers/blob/0f0ad2966e95c80e0d9866d0324059875f6142b1/lambdas/eosioBrewAutoPR.js) lambda need a new [comparator](https://github.com/EOSIO/auto-events-subscribers/blob/0f0ad2966e95c80e0d9866d0324059875f6142b1/lambdas/eosioBrewAutoPR.js#L88) written which understands semantic versioning and also ignores alpha, betas, and release candidates. While we have had releases with double-digit patch versions, this is the first one on `master` that needed to be added to `brew`. Since Automation needs time to write a new comparator, and since the lambda did not DLQ and thus cannot be redriven, I have opened this pull request by hand.