### PR TITLE
Fix(brew): corrects issue #50 (brew update warning)

### DIFF
--- a/doxygen.rb
+++ b/doxygen.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class Doxygen < Formula
   desc "EOSIO VERSION (no cmake): Generate documentation for several programming languages"
   homepage "http://www.doxygen.org/"
@@ -15,7 +18,7 @@ class Doxygen < Formula
   deprecated_option "with-libclang" => "with-llvm"
   deprecated_option "with-qt5" => "with-qt"
 
-  #depends_on "cmake" => :build
+  # depends_on "cmake" => :build
   depends_on "graphviz" => :optional
   depends_on "qt" => :optional
 
@@ -32,7 +35,7 @@ class Doxygen < Formula
     args << "-Duse_libclang=ON -DLLVM_CONFIG=#{Formula["llvm"].opt_bin}/llvm-config" if build.with? "llvm"
 
     mkdir "build" do
-      system "/Users/#{ENV['USER']}/bin/cmake", "..", *args
+      system "/Users/#{ENV["USER"]}/bin/cmake", "..", *args
       system "make"
     end
     bin.install Dir["build/bin/*"]

--- a/eosio.rb
+++ b/eosio.rb
@@ -1,25 +1,27 @@
+# typed: false
+# frozen_string_literal: true
+
 class Eosio < Formula
+  homepage "https://github.com/eosio/eos"
+  url "https://github.com/eosio/eos/archive/v2.0.12.tar.gz"
+  version "2.0.12"
+  revision 0
 
-   homepage "https://github.com/eosio/eos"
-   revision 0
-   url "https://github.com/eosio/eos/archive/v2.0.12.tar.gz"
-   version "2.0.12"
+  bottle do
+    root_url "https://github.com/eosio/eos/releases/download/v2.0.12"
+    sha256 mojave: "2e03b4fe73e0cdc70e607b35e35294f49d6833439176b4dedc846e62a3b77005"
+  end
 
-   option :universal
+  option :universal
 
-   depends_on "gmp"
-   depends_on "gettext"
-   depends_on "openssl@1.1"
-   depends_on "libusb"
-   depends_on :macos => :mojave
-   depends_on :arch =>  :intel
-
-   bottle do
-      root_url "https://github.com/eosio/eos/releases/download/v2.0.12"
-      sha256 "2e03b4fe73e0cdc70e607b35e35294f49d6833439176b4dedc846e62a3b77005" => :mojave
-   end
-   def install
-      raise "Error, only supporting binary packages at this time"
-   end
+  depends_on arch: :intel
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "libusb"
+  depends_on macos: :mojave
+  depends_on "openssl@1.1"
+  def install
+    raise "Error, only supporting binary packages at this time"
+  end
 end
 __END__

--- a/eosio.rb
+++ b/eosio.rb
@@ -1,15 +1,13 @@
 # typed: false
 # frozen_string_literal: true
+class Eosio < Formula
 
    homepage "https://github.com/eosio/eos"
    revision 0
    url "https://github.com/eosio/eos/archive/v2.1.0.tar.gz"
    version "2.1.0"
 
-  bottle do
-    root_url "https://github.com/eosio/eos/releases/download/v2.0.12"
-    sha256 mojave: "2e03b4fe73e0cdc70e607b35e35294f49d6833439176b4dedc846e62a3b77005"
-  end
+option :universal
 
    depends_on "gmp"
    depends_on "openssl@1.1"


### PR DESCRIPTION
- PR to fix Homebrew CLI [#50](https://github.com/EOSIO/homebrew-eosio/issues/50#issue-860758248) warning ⤵ and the deprecated `"digest" => :tag` call that was causing it.
- I also made a few styling tweaks but stayed mindful of the existing conventions.

```shell
$ brew upgrade eosio
Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the eosio/eosio tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/eosio/homebrew-eosio/eosio.rb:19
```

- Cheers 🥂 