### PR TITLE
eos:v2.1.0 release

### DIFF
--- a/eosio.rb
+++ b/eosio.rb
@@ -2,21 +2,21 @@ class Eosio < Formula
 
    homepage "https://github.com/eosio/eos"
    revision 0
-   url "https://github.com/eosio/eos/archive/v2.0.12.tar.gz"
-   version "2.0.12"
+   url "https://github.com/eosio/eos/archive/v2.1.0.tar.gz"
+   version "2.1.0"
 
    option :universal
 
    depends_on "gmp"
-   depends_on "gettext"
    depends_on "openssl@1.1"
    depends_on "libusb"
+   depends_on "libpqxx"
    depends_on :macos => :mojave
    depends_on :arch =>  :intel
 
    bottle do
-      root_url "https://github.com/eosio/eos/releases/download/v2.0.12"
-      sha256 "2e03b4fe73e0cdc70e607b35e35294f49d6833439176b4dedc846e62a3b77005" => :mojave
+      root_url "https://github.com/eosio/eos/releases/download/v2.1.0"
+      sha256 "b1562e0e2d97288104839884871212d4c2ab1b54b0764aa9bb5f24bb1d5d37ab" => :catalina
    end
    def install
       raise "Error, only supporting binary packages at this time"


### PR DESCRIPTION
From [#help-automation](https://blockone.slack.com/archives/CMTAZ9L4D/p1621489322026100) and [AUTO-877](https://blockone.atlassian.net/browse/AUTO-877), this pull request needs to be created manually from eosio [build 28539](https://buildkite.com/EOSIO/eosio/builds/28539#8af1b87f-df89-47ec-afa5-d77c8512280a) this time around due to a suspected bug in GitHub.